### PR TITLE
carbonbot: fail on redis connection issues

### DIFF
--- a/carbonbot/Cargo.toml
+++ b/carbonbot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carbonbot"
-version = "1.9.2"
+version = "1.9.3"
 authors = ["soulmachine <soulmachine@gmail.com>"]
 edition = "2021"
 

--- a/carbonbot/src/writers/mod.rs
+++ b/carbonbot/src/writers/mod.rs
@@ -92,6 +92,7 @@ fn create_redis_writer_thread(rx: Receiver<Message>, redis_url: String) -> JoinH
             let topic = format!("carbonbot:{}", msg_type);
             if let Err(err) = redis_conn.publish::<&str, String, i64>(&topic, s) {
                 error!("{}", err);
+                return;
             }
         }
     })


### PR DESCRIPTION
When the connection to redis was lost it doesn't reconnect automatically. On a connection loss it just keeps spitting out messages like`[2021-11-16T18:10:28Z ERROR carbonbot::writers] Broken pipe (os error 32)`.

With this small change it quits on a connection loss, so docker can restart. 