### PR TITLE
fix broken filtering

### DIFF
--- a/carbonbot/src/main.rs
+++ b/carbonbot/src/main.rs
@@ -88,12 +88,8 @@ fn main() {
     let specified_symbols = if args.len() == 4 {
         Vec::new()
     } else {
-        let all_symbols = fetch_symbols_retry(exchange, market_type);
-        let specified_symbols: Vec<String> = args[4].split(",").map(|s| s.to_string()).collect();
-        let symbols: Vec<String> = specified_symbols
-            .into_iter()
-            .filter(|s| all_symbols.contains(s))
-            .collect();
+        let mut symbols = fetch_symbols_retry(exchange, market_type);
+        symbols.retain(|symbol| args[4].split(',').any(|part| symbol.contains(part)));
         info!("target symbols: {:?}", symbols);
         symbols
     };

--- a/carbonbot/src/writers/mod.rs
+++ b/carbonbot/src/writers/mod.rs
@@ -92,6 +92,7 @@ fn create_redis_writer_thread(rx: Receiver<Message>, redis_url: String) -> JoinH
             let topic = format!("carbonbot:{}", msg_type);
             if let Err(err) = redis_conn.publish::<&str, String, i64>(&topic, s) {
                 error!("{}", err);
+                return;
             }
         }
     })


### PR DESCRIPTION
Hi @soulmachine 

Commit `b0b102b37449a765ecaa40bc8c7995cf69ca3a1b` broke this feature

I tested many exchanges with my implementation and it worked perfectly fine. Or did I miss something? I'd be in favor of keeping it like that, as a simple one-liner the code is IMHO much more readable