### PR TITLE
Fix bybit `max_trading_qty` type to f64

### DIFF
--- a/crypto-markets/src/exchanges/bybit.rs
+++ b/crypto-markets/src/exchanges/bybit.rs
@@ -42,7 +42,7 @@ struct PriceFilter {
 
 #[derive(Serialize, Deserialize)]
 struct LotSizeFilter {
-    max_trading_qty: i64,
+    max_trading_qty: f64,
     min_trading_qty: f64,
     qty_step: f64,
 }
@@ -183,7 +183,7 @@ fn to_market(raw_market: &BybitMarket) -> Market {
         },
         quantity_limit: Some(QuantityLimit {
             min: raw_market.lot_size_filter.min_trading_qty,
-            max: Some(raw_market.lot_size_filter.max_trading_qty as f64),
+            max: Some(raw_market.lot_size_filter.max_trading_qty),
         }),
         contract_value: Some(1.0),
         delivery_date,


### PR DESCRIPTION
Hi @soulmachine 

First of all: Thanks for your absolutely great effort to provide such a library!

I ran into this error for the bybit exchange recently and found a simple fix, too:

```
2022-02-09T18:46:59.718828Z  WARN crypto_crawler::crawlers::utils: The 0th time, invalid type: floating point `1.5`, expected i64 at line 1 column 17692
2022-02-09T18:47:01.331758Z  WARN crypto_crawler::crawlers::utils: The 1th time, invalid type: floating point `1.5`, expected i64 at line 1 column 17692
2022-02-09T18:47:02.520792Z  WARN crypto_crawler::crawlers::utils: The 2th time, invalid type: floating point `1.5`, expected i64 at line 1 column 17692
2022-02-09T18:47:04.505322Z  WARN crypto_crawler::crawlers::utils: The 3th time, invalid type: floating point `1.5`, expected i64 at line 1 column 17692
2022-02-09T18:47:08.092760Z ERROR crypto_crawler::crawlers::utils: The 4th time, invalid type: floating point `1.5`, expected i64 at line 1 column 17692
thread 'tokio-runtime-worker' panicked at 'Invalid symbols: BTCUSD, bybit inverse_swap available trading symbols are ', ***/crypto-crawler-rs/crypto-crawler/src/crawlers/utils.rs:90:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Apparently, bybit changed the type of the `max_trading_qty` field for one of the symbols (YFIUSDT, see: https://api.bybit.com/v2/public/symbols)

<img width="296" alt="Screenshot 2022-02-10 at 12 22 08" src="https://user-images.githubusercontent.com/48974/153397308-f076ad7c-38dc-408d-a13e-f036afb4d2c1.png">

Please find attached a simple fix!